### PR TITLE
Improve the transactions model

### DIFF
--- a/src/investir/investir.py
+++ b/src/investir/investir.py
@@ -6,7 +6,7 @@ import pathlib
 from .config import Config
 from .logging import setup_logging
 from .parser.factory import ParserFactory
-from .transaction import OrderType, TransferType
+from .transaction import Acquisition, Disposal
 from .trhistory import TrHistory
 
 logger = logging.getLogger(__name__)
@@ -38,14 +38,14 @@ def create_orders_command(subparser, parent_parser) -> None:
         '--acquisitions',
         action='store_const',
         dest='order_type',
-        const=OrderType.ACQUISITION,
+        const=Acquisition,
         help='show only acquisitions',
     )
     type_group.add_argument(
         '--disposals',
         action='store_const',
         dest='order_type',
-        const=OrderType.DISPOSAL,
+        const=Disposal,
         help='show only disposals',
     )
 
@@ -73,15 +73,15 @@ def create_transfers_command(subparser, parent_parser) -> None:
     type_group.add_argument(
         '--deposits',
         action='store_const',
-        dest='transfer_type',
-        const=TransferType.DEPOSIT,
+        dest='amount_filter',
+        const=lambda tr: tr.amount > 0.0,
         help='show only acquisitions',
     )
     type_group.add_argument(
         '--widthdraws',
         action='store_const',
-        dest='transfer_type',
-        const=TransferType.WITHDRAW,
+        dest='amount_filter',
+        const=lambda tr: tr.amount < 0.0,
         help='show only disposals'
     )
 
@@ -159,7 +159,7 @@ def main() -> None:
         filters.append(lambda tr: tr.ticker == args.ticker)
 
     if hasattr(args, 'order_type') and args.order_type is not None:
-        filters.append(lambda tr: tr.type == args.order_type)
+        filters.append(lambda tr: isinstance(tr, args.order_type))
 
     if args.tax_year is not None:
         filters.append(lambda tr: tr.tax_year() == args.tax_year)

--- a/src/investir/trhistory.py
+++ b/src/investir/trhistory.py
@@ -1,9 +1,10 @@
 from prettytable import PrettyTable
 
 from .transaction import (
-    Order, OrderType,
+    Order,
+    Acquisition,
     Dividend,
-    Transfer, TransferType,
+    Transfer,
     Interest)
 from .utils import multiple_filter
 
@@ -42,21 +43,26 @@ class TrHistory:
     def show_orders(self, filters=None) -> None:
         table = PrettyTable(
             field_names=(
-                'Date', 'Ticker', 'Disposal', 'Price',
-                'Quantity', 'Fees', 'Total', 'Order ID'))
+                'ID', 'Date', 'Ticker', 'Total Cost', 'Net Proceeds',
+                'Quantity', 'Price', 'Fees'))
 
         for tr in multiple_filter(filters, self._orders):
-            type_str = 'Yes' if tr.type == OrderType.DISPOSAL else ' '
+            net_proceeds = ''
+            total_cost = ''
+            if isinstance(tr, Acquisition):
+                total_cost = str(round(tr.total_cost, 2))
+            else:
+                net_proceeds = str(round(tr.net_proceeds, 2))
 
             table.add_row([
+                tr.id,
                 tr.timestamp.strftime('%Y-%m-%d %H:%M:%S'),
                 tr.ticker,
-                type_str,
-                tr.price,
+                total_cost,
+                net_proceeds,
                 tr.quantity,
-                tr.fees,
-                round(tr.total_amount(), 2),
-                tr.order_id])
+                round(tr.price, 2),
+                tr.fees])
 
         print(table)
 
@@ -75,14 +81,11 @@ class TrHistory:
 
     def show_transfers(self, filters=None):
         table = PrettyTable(
-            field_names=('Date', 'Withdraw', 'Amount'))
+            field_names=('Date', 'Amount'))
 
         for tr in multiple_filter(filters, self._transfers):
-            type_str = 'Yes' if tr.type == TransferType.WITHDRAW else ' '
-
             table.add_row([
                 tr.timestamp.strftime('%Y-%m-%d %H:%M:%S'),
-                type_str,
                 tr.amount])
 
         print(table)

--- a/tests/parser/test_freetradeparser.py
+++ b/tests/parser/test_freetradeparser.py
@@ -10,7 +10,7 @@ from investir.parser.exceptions import (
     CalculatedAmountError,
     FeeError)
 from investir.parser.freetrade import FreetradeParser
-from investir.transaction import OrderType, TransferType
+from investir.transaction import Acquisition, Disposal
 
 
 @pytest.fixture(name='create_parser')
@@ -119,18 +119,18 @@ def test_parser_happy_path(create_parser):
     assert len(parser_result.orders) == 2
 
     order = parser_result.orders[0]
+    assert isinstance(order, Acquisition)
     assert order.timestamp == timestamp
+    assert order.amount == Decimal('1325.00')
     assert order.ticker == 'AMZN'
-    assert order.type == OrderType.ACQUISITION
-    assert order.price == Decimal('132.5')
     assert order.quantity == Decimal('10')
     assert order.fees == Decimal('5.2')
 
     order = parser_result.orders[1]
+    assert isinstance(order, Disposal)
     assert order.timestamp == timestamp
+    assert order.amount == Decimal('1118.25')
     assert order.ticker == 'SWKS'
-    assert order.type == OrderType.DISPOSAL
-    assert order.price == Decimal('532.5')
     assert order.quantity == Decimal('2.1')
     assert order.fees == Decimal('6.4')
 
@@ -138,21 +138,19 @@ def test_parser_happy_path(create_parser):
     dividend = parser_result.dividends[0]
 
     assert dividend.timestamp == timestamp
-    assert dividend.ticker == 'SWKS'
     assert dividend.amount == Decimal('2.47')
+    assert dividend.ticker == 'SWKS'
     assert dividend.withheld == Decimal('0.4375520000')
 
     assert len(parser_result.transfers) == 2
     transfer = parser_result.transfers[0]
 
     assert transfer.timestamp == timestamp
-    assert transfer.type == TransferType.DEPOSIT
     assert transfer.amount == Decimal('1000.00')
 
     transfer = parser_result.transfers[1]
     assert transfer.timestamp == timestamp
-    assert transfer.type == TransferType.WITHDRAW
-    assert transfer.amount == Decimal('500.25')
+    assert transfer.amount == Decimal('-500.25')
 
     assert len(parser_result.interest) == 1
     interest = parser_result.interest[0]

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from decimal import Decimal
+
+from investir.transaction import Order, Acquisition, Disposal
+
+
+def test_acquisition_order():
+    count = Order.order_count
+
+    order = Acquisition(
+        datetime(2022, 4, 6, 18, 4, 50),
+        amount=Decimal(100.0),
+        ticker='AMZN',
+        quantity=Decimal(20.0),
+        fees=Decimal(1.4),
+        order_id='ORDER')
+
+    assert order.tax_year() == 2022
+    assert order.id == count + 1
+    assert order.tax_year() == 2022
+    assert order.price == order.amount / order.quantity
+    assert order.total_cost == order.amount + order.fees
+
+
+def test_disposal_order():
+    count = Order.order_count
+
+    order = Disposal(
+        datetime(2023, 4, 6, 18, 4, 50),
+        amount=Decimal(50.0),
+        ticker='AMZN',
+        quantity=Decimal(10.0),
+        fees=Decimal(1.7),
+        order_id='ORDER')
+
+    assert order.tax_year() == 2023
+    assert order.id == count + 1
+    assert order.tax_year() == 2023
+    assert order.price == order.amount / order.quantity
+    assert order.net_proceeds == order.amount - order.fees

--- a/tests/test_trhistory.py
+++ b/tests/test_trhistory.py
@@ -2,52 +2,45 @@ from datetime import datetime
 from decimal import Decimal
 
 from investir.transaction import (
-    Order, OrderType,
-    Dividend,
-    Transfer, TransferType,
-    Interest)
+    Acquisition, Disposal, Dividend, Transfer, Interest)
 from investir.trhistory import TrHistory
 
 
-ORDER1 = Order(
+ORDER1 = Acquisition(
     datetime(2023, 4, 6, 18, 4, 50),
-    'AMZN',
-    OrderType.ACQUISITION,
-    Decimal(1.0),
-    Decimal(2.0),
-    Decimal(3.0),
-    'ORDER1')
+    ticker='AMZN',
+    amount=Decimal(10.0),
+    quantity=Decimal(1.0),
+    fees=Decimal(0.5),
+    order_id='ORDER1')
 
-ORDER2 = Order(
+ORDER2 = Disposal(
     datetime(2024, 2, 5, 14, 7, 20),
-    'GOOG',
-    OrderType.DISPOSAL,
-    Decimal(3.0),
-    Decimal(2.0),
-    Decimal(1.0),
-    'ORDER2')
+    ticker='GOOG',
+    amount=Decimal(15.0),
+    quantity=Decimal(2.0),
+    fees=Decimal(1.0),
+    order_id='ORDER2')
 
 DIVIDEND1 = Dividend(
     datetime(2023, 2, 5, 14, 7, 20),
-    'AMZN',
-    Decimal(5.0),
-    Decimal(2.0))
+    ticker='AMZN',
+    amount=Decimal(5.0),
+    withheld=Decimal(2.0))
 
 DIVIDEND2 = Dividend(
     datetime(2024, 2, 5, 14, 7, 20),
-    'GOOG',
-    Decimal(5.0),
-    Decimal(2.0))
+    ticker='GOOG',
+    amount=Decimal(5.0),
+    withheld=Decimal(2.0))
 
 TRANSFER1 = Transfer(
     datetime(2023, 2, 5, 14, 7, 20),
-    TransferType.DEPOSIT,
     Decimal(3000.0))
 
 TRANSFER2 = Transfer(
     datetime(2024, 2, 5, 14, 7, 20),
-    TransferType.WITHDRAW,
-    Decimal(1000.0))
+    Decimal(-1000.0))
 
 INTEREST1 = Interest(
     datetime(2023, 2, 5, 14, 7, 20),
@@ -104,8 +97,8 @@ def test_trhistory_transfers_are_sorted_by_timestamp():
 
     transfers = tr_hist.transfers()
     assert len(transfers) == 2
-    assert transfers[0].type == TransferType.DEPOSIT
-    assert transfers[1].type == TransferType.WITHDRAW
+    assert transfers[0].amount == Decimal('3000')
+    assert transfers[1].amount == Decimal('-1000')
 
 
 def test_trhistory_interest_is_sorted_by_timestamp():


### PR DESCRIPTION
Improve the transactions model by:

* Define a `Transaction` base class common to all transactions.
* Add specific classes for acquisitions and disposals.
* Add an `id` field to the Order class that is increased for each new order to help with order identification when doing the tax calculation.
* Add a `notes` field to each order to store tax calculation notes.
* Store the order amount instead of calculating it from the share price and quantity. This is more precise if rounding issues are present.
* Remove the `TransferType` enum and represent withdraws using negative numbers instead.
* Improve the `__hash__` implementations for the different transactions.