### PR TITLE
Fix parsing of withdrawals for Trading212

### DIFF
--- a/src/investir/parser/freetrade.py
+++ b/src/investir/parser/freetrade.py
@@ -222,7 +222,7 @@ class FreetradeParser:
         total_amount = Decimal(row["Total Amount"])
 
         if tr_type == "WITHDRAWAL":
-            total_amount *= -1
+            total_amount = -abs(total_amount)
 
         self._transfers.append(Transfer(timestamp, total_amount))
 

--- a/src/investir/parser/trading212.py
+++ b/src/investir/parser/trading212.py
@@ -247,7 +247,7 @@ class Trading212Parser:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
 
         if action == "Withdrawal":
-            total *= -1
+            total = -abs(total)
 
         self._transfers.append(Transfer(timestamp, tr_id=tr_id, amount=total))
 

--- a/tests/parsers/test_trading212.py
+++ b/tests/parsers/test_trading212.py
@@ -130,7 +130,7 @@ def test_parser_happy_path(create_parser):  # noqa: PLR0915
     withdrawal = {
         "Action": "Withdrawal",
         "Time": TIMESTAMP,
-        "Total": "500.25",
+        "Total": "-500.25",
         "Currency (Total)": "GBP",
     }
 


### PR DESCRIPTION
The amounts for Trading212 withdrawals are already negative values. This commit changes the parsers to be more robust and not make assumptions about the sign for these amounts.