### PR TITLE
Require newer version of Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "prettytable ~= 3.10.0",
   "python-dateutil ~= 2.9.0",
   "PyYAML ~= 6.0.0",
-  "typer ~= 0.12.0",
+  "typer ~= 0.15.3",
   "yfinance ~= 0.2.54",
 ]
 optional-dependencies.lint = [


### PR DESCRIPTION
Require a newer version of Typer to fix an issue with file path autocompletion [1].

[1]: https://github.com/fastapi/typer/discussions/625