### PR TITLE
parser/freetrade: Update parser for recent changes in CSV exports

### DIFF
--- a/src/investir/parser/freetrade.py
+++ b/src/investir/parser/freetrade.py
@@ -36,6 +36,15 @@ from investir.utils import dict2str, money, raise_or_warn, read_decimal, read_st
 logger = logging.getLogger(__name__)
 
 
+def read_field_with_fallback(
+    row: Mapping[str, str], newer_field: str, legacy_field: str
+) -> str:
+    if newer_field in row:
+        return row[newer_field]
+
+    return row[legacy_field]
+
+
 @ParserFactory.register("Freetrade")
 class FreetradeParser:
     FIELDS: Final = (
@@ -43,31 +52,35 @@ class FreetradeParser:
         "Type",
         "Timestamp",
         "Account Currency",
-        "Total Amount",
+        "Total Amount in Account Currency",
         "Buy / Sell",
         "Ticker",
         "ISIN",
         "Price per Share in Account Currency",
         "Stamp Duty",
         "Quantity",
-        "Venue",
         "Order ID",
-        "Order Type",
-        "Instrument Currency",
-        "Total Shares Amount",
         "Price per Share",
         "FX Rate",
         "Base FX Rate",
-        "FX Fee (BPS)",
         "FX Fee Amount",
-        "Dividend Ex Date",
-        "Dividend Pay Date",
         "Dividend Eligible Quantity",
         "Dividend Amount Per Share",
-        "Dividend Gross Distribution Amount",
-        "Dividend Net Distribution Amount",
         "Dividend Withheld Tax Percentage",
         "Dividend Withheld Tax Amount",
+        # Legacy
+        "Total Amount",
+        "Total Shares Amount",
+        # Ignored
+        "Venue",
+        "Order Type",
+        "Instrument Currency",
+        "Total Amount in Instrument Currency",
+        "FX Fee (BPS)",
+        "Dividend Ex Date",
+        "Dividend Pay Date",
+        "Dividend Gross Distribution Amount",
+        "Dividend Net Distribution Amount",
         "Stock Split Ex Date",
         "Stock Split Pay Date",
         "Stock Split New ISIN",
@@ -85,7 +98,7 @@ class FreetradeParser:
         "Stock Split Fractional Payout Cash Received Currency",
     )
 
-    REQUIRED: Final = ("Type", "Timestamp", "Total Amount", "Account Currency")
+    REQUIRED: Final = ("Type", "Timestamp", "Account Currency")
 
     def __init__(self, csv_file: Path) -> None:
         self._csv_file = csv_file
@@ -98,6 +111,12 @@ class FreetradeParser:
         with self._csv_file.open(encoding="utf-8") as file:
             reader = DictReader(file)
             fieldnames = reader.fieldnames or []
+
+        if (
+            "Total Amount in Account Currency" not in fieldnames
+            and "Total Amount" not in fieldnames
+        ):
+            return False
 
         return all(f in fieldnames for f in self.REQUIRED)
 
@@ -137,7 +156,10 @@ class FreetradeParser:
 
                 if fn := parse_fn.get(tr_type):
                     timestamp = parse_timestamp(row["Timestamp"])
-                    total = money(row["Total Amount"], row["Account Currency"])
+                    total_str = read_field_with_fallback(
+                        row, "Total Amount", "Total Amount in Account Currency"
+                    )
+                    total = money(total_str, row["Account Currency"])
 
                     fn(row, tr_type, timestamp, total)
 

--- a/src/investir/parser/trading212.py
+++ b/src/investir/parser/trading212.py
@@ -96,6 +96,8 @@ class Trading212Parser:
         "Merchant category",
     )
 
+    REQUIRED: Final = ("Action", "Time")
+
     def __init__(self, csv_file: Path) -> None:
         self._csv_file = csv_file
         self._orders: list[Order] = []
@@ -108,13 +110,10 @@ class Trading212Parser:
             reader = DictReader(file)
             fieldnames = reader.fieldnames or []
 
-        if "Action" not in fieldnames or "Time" not in fieldnames:
-            return False
-
         if "Total" not in fieldnames and "Total (GBP)" not in fieldnames:
             return False
 
-        return True
+        return all(f in fieldnames for f in self.REQUIRED)
 
     def parse(self) -> ParsingResult:
         parse_fn = {

--- a/tests/parser/test_freetrade.py
+++ b/tests/parser/test_freetrade.py
@@ -22,12 +22,37 @@ from investir.utils import sterling
 
 TIMESTAMP: Final = datetime(2021, 7, 26, 7, 41, 32, 582, tzinfo=timezone.utc)
 
+LEGACY_FIELDS: Final = {
+    "Total Amount",
+    "Total Shares Amount",
+}
+
+RECENT_FIELDS: Final = {
+    "Total Amount in Account Currency",
+    "Total Amount in Instrument Currency",
+    "Stock Split Ex Date",
+    "Stock Split Pay Date",
+    "Stock Split New ISIN",
+    "Stock Split Rate of Share Outturn From",
+    "Stock Split Rate of Share Outturn To",
+    "Stock Split Maintain Holding of Initial ISIN",
+    "Stock Split New Share Quantity",
+    "Stock Split Rate of Cash Outturn Amount",
+    "Stock Split Rate of Cash Outturn Currency",
+    "Stock Split Cash Outturn Received Amount",
+    "Stock Split Has Fractional Payout",
+    "Stock Split Rate of Fractional Payout Amount",
+    "Stock Split Rate of Fractional Payout Currency",
+    "Stock Split Fractional Payout Cash Received Amount",
+    "Stock Split Fractional Payout Cash Received Currency",
+}
+
 ACQUISITION: Final = {
     "Title": "Amazon",
     "Type": "ORDER",
     "Timestamp": TIMESTAMP,
     "Account Currency": "GBP",
-    "Total Amount": "1330.20",
+    "Total Amount in Account Currency": "1330.20",
     "Buy / Sell": "BUY",
     "Ticker": "AMZN",
     "ISIN": "AMZN-ISIN",
@@ -41,7 +66,7 @@ DISPOSAL: Final = {
     "Type": "ORDER",
     "Timestamp": TIMESTAMP,
     "Account Currency": "GBP",
-    "Total Amount": "1111.85",
+    "Total Amount in Account Currency": "1111.85",
     "Buy / Sell": "SELL",
     "Ticker": "SWKS",
     "ISIN": "SWKS-ISIN",
@@ -55,7 +80,7 @@ DIVIDEND: Final = {
     "Type": "DIVIDEND",
     "Timestamp": TIMESTAMP,
     "Account Currency": "GBP",
-    "Total Amount": "2.47",
+    "Total Amount in Account Currency": "2.47",
     "Ticker": "SWKS",
     "ISIN": "SWKS-ISIN",
     "Base FX Rate": "0.75440000",
@@ -69,11 +94,15 @@ DIVIDEND: Final = {
 @pytest.fixture
 def make_parser(tmp_path) -> Callable:
     def _wrapper(
-        rows: Sequence[Mapping[str, str]], fields: Sequence[str] | None = None
+        rows: Sequence[Mapping[str, str]], legacy_fields: bool = False
     ) -> FreetradeParser:
         csv_file = tmp_path / "transactions.csv"
         with csv_file.open("w", encoding="utf-8") as file:
-            writer = csv.DictWriter(file, fieldnames=fields or FreetradeParser.FIELDS)
+            if not legacy_fields:
+                field_names = set(FreetradeParser.FIELDS) - LEGACY_FIELDS
+            else:
+                field_names = set(FreetradeParser.FIELDS) - RECENT_FIELDS
+            writer = csv.DictWriter(file, fieldnames=field_names)
             writer.writeheader()
             writer.writerows(rows)
         return FreetradeParser(csv_file)
@@ -102,21 +131,21 @@ def test_parser_happy_path(make_parser):
         "Type": "TOP_UP",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "1000.00",
+        "Total Amount in Account Currency": "1000.00",
     }
 
     withdrawal = {
         "Type": "WITHDRAWAL",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "500.25",
+        "Total Amount in Account Currency": "500.25",
     }
 
     interest = {
         "Type": "INTEREST_FROM_CASH",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "4.65",
+        "Total Amount in Account Currency": "4.65",
     }
 
     monthly_statement = {"Type": "MONTHLY_STATEMENT"}
@@ -186,41 +215,39 @@ def test_parser_happy_path(make_parser):
     assert interest.total == sterling("4.65")
 
 
-def test_parser_legacy_export(make_parser):
-    new_fields = set(
-        [
-            "Stock Split Ex Date",
-            "Stock Split Pay Date",
-            "Stock Split New ISIN",
-            "Stock Split Rate of Share Outturn From",
-            "Stock Split Rate of Share Outturn To",
-            "Stock Split Maintain Holding of Initial ISIN",
-            "Stock Split New Share Quantity",
-            "Stock Split Rate of Cash Outturn Amount",
-            "Stock Split Rate of Cash Outturn Currency",
-            "Stock Split Cash Outturn Received Amount",
-            "Stock Split Has Fractional Payout",
-            "Stock Split Rate of Fractional Payout Amount",
-            "Stock Split Rate of Fractional Payout Currency",
-            "Stock Split Fractional Payout Cash Received Amount",
-            "Stock Split Fractional Payout Cash Received Currency",
-        ]
-    )
+def test_parser_legacy_fields(make_parser):
+    acquisition: Final = {
+        "Title": "Amazon",
+        "Type": "ORDER",
+        "Timestamp": TIMESTAMP,
+        "Account Currency": "GBP",
+        "Total Amount": "1330.20",
+        "Total Shares Amount": "0.0",
+        "Buy / Sell": "BUY",
+        "Ticker": "AMZN",
+        "ISIN": "AMZN-ISIN",
+        "Price per Share in Account Currency": "132.5",
+        "Stamp Duty": "5.2",
+        "Quantity": "10.0",
+    }
 
-    legacy_fields = [
-        field for field in FreetradeParser.FIELDS if field not in new_fields
-    ]
-
-    parser = make_parser([ACQUISITION], legacy_fields)
+    parser = make_parser([acquisition], legacy_fields=True)
     assert parser.can_parse()
     assert len(parser.parse().orders) == 1
 
 
 def test_parser_with_missing_required_field(make_parser_with_custom_fields):
     fields = list(FreetradeParser.FIELDS)
+    fields.remove("Total Amount in Account Currency")
     fields.remove("Total Amount")
     parser = make_parser_with_custom_fields(fields)
     assert parser.can_parse() is False
+
+    for field in ["Type", "Timestamp", "Account Currency"]:
+        fields = list(FreetradeParser.FIELDS)
+        fields.remove(field)
+        parser = make_parser_with_custom_fields(fields)
+        assert parser.can_parse() is False, f"{field} field test failed"
 
 
 def test_parser_with_unknown_field(make_parser_with_custom_fields):
@@ -275,7 +302,7 @@ def test_parser_order_too_old(make_parser):
 
 def test_parser_order_calculated_amount_mismatch(make_parser):
     order = dict(ACQUISITION)
-    order["Total Amount"] = "7.5"
+    order["Total Amount in Account Currency"] = "7.5"
     parser = make_parser([order])
     assert parser.can_parse()
     with pytest.raises(CalculatedAmountError):
@@ -284,7 +311,7 @@ def test_parser_order_calculated_amount_mismatch(make_parser):
 
 def test_parser_dividend_calculated_amount_mismatch(make_parser):
     dividend = dict(DIVIDEND)
-    dividend["Total Amount"] = "2.50"
+    dividend["Total Amount in Account Currency"] = "2.50"
     parser = make_parser([dividend])
     assert parser.can_parse()
     with pytest.raises(CalculatedAmountError):
@@ -297,7 +324,7 @@ def test_parser_free_share(make_parser):
         "Type": "FREESHARE_ORDER",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "11.88",
+        "Total Amount in Account Currency": "11.88",
         "Ticker": "IMOS",
         "ISIN": "US16965P2020",
         "Quantity": "1.00",
@@ -328,7 +355,7 @@ def test_parser_internal_transfer_inbound(make_parser):
         "Type": "INTERNAL_TRANSFER",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "10000.00",
+        "Total Amount in Account Currency": "10000.00",
     }
 
     parser = make_parser([internal_transfer])
@@ -349,7 +376,7 @@ def test_parser_internal_transfer_outbound(make_parser):
         "Type": "INTERNAL_TRANSFER",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "5000.00",
+        "Total Amount in Account Currency": "5000.00",
     }
 
     parser = make_parser([internal_transfer])
@@ -370,7 +397,7 @@ def test_parser_internal_transfer_unknown_type(make_parser):
         "Type": "INTERNAL_TRANSFER",
         "Timestamp": TIMESTAMP,
         "Account Currency": "GBP",
-        "Total Amount": "1000.00",
+        "Total Amount in Account Currency": "1000.00",
     }
 
     parser = make_parser([internal_transfer])


### PR DESCRIPTION
Update parser for the recent changes Freetrade made in their CSV exports:

    * Total Amount -> Total Amount in Account Currency
    * Total Shares Amount -> Total Amount in Instrument Currency

Fixes #76.